### PR TITLE
performSelector在返回为空时ios8下会crash

### DIFF
--- a/CTMediator/CTMediator/CTMediator.m
+++ b/CTMediator/CTMediator/CTMediator.m
@@ -80,6 +80,7 @@
     
     if (target == nil) {
         // 这里是处理无响应请求的地方之一，这个demo做得比较简单，如果没有可以响应的target，就直接return了。实际开发过程中是可以事先给一个固定的target专门用于在这个时候顶上，然后处理这种请求的
+        NSAssert(NO, @"target not founded");
         return nil;
     }
     
@@ -112,6 +113,7 @@
             } else {
                 // 这里也是处理无响应请求的地方，在notFound都没有的时候，这个demo是直接return了。实际开发过程中，可以用前面提到的固定的target顶上的。
                 [self.cachedTarget removeObjectForKey:targetClassString];
+                NSAssert(NO, @"target not founded");
                 return nil;
             }
         }


### PR DESCRIPTION
修正target返回void在ios8下的crash问题，原因是performSelector要求返回值为id类型，而void返回不符合签名，在ios8下我测试是会遇到crash，这里使用判断如果返回值为void，使用invocation替代