### PR TITLE
Feat/short name

### DIFF
--- a/CTMediator.podspec
+++ b/CTMediator.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "CTMediator"
-  s.version      = "32"
+  s.version      = "33"
   s.summary      = "CTMediator."
 
   # This description is used to generate tags and improve search results.

--- a/CTMediator/CTMediator/CTMediator.h
+++ b/CTMediator/CTMediator/CTMediator.h
@@ -21,3 +21,8 @@ extern NSString * _Nonnull const kCTMediatorParamsKeySwiftTargetModuleName;
 - (void)releaseCachedTargetWithFullTargetName:(NSString * _Nullable)fullTargetName;
 
 @end
+
+// 简化调用单例的函数
+CTMediator* _Nonnull CT() {
+    return [CTMediator sharedInstance];
+}


### PR DESCRIPTION
新增一个简化调用 CTMediator 单例的函数，将[CTMediator sharedInstance] 简化为 CT() 来获取单利对象。
这有助于在 OC 以及 Swift 环境下，更简洁的调用使用 CTMediator 进行组件的调用。